### PR TITLE
Update Qtum Rosetta to run with Qtum v25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,9 @@ WORKDIR /app
 #  libcurl4-openssl-dev libdb++-dev libevent-dev libssl-dev libtool pkg-config python python-pip libzmq3-dev wget
 
 
-#ADD http://198.211.122.66/qtumd /app/qtumd
-ENV QTUM_RELEASE_URL https://github.com/qtumproject/qtum/releases/download/v24.1
-ENV QTUM_ARCHIVE qtum-24.1-x86_64-linux-gnu.tar.gz
-ENV QTUM_FOLDER qtum-24.1
+ENV QTUM_RELEASE_URL https://github.com/qtumproject/qtum/releases/download/v25.1
+ENV QTUM_ARCHIVE qtum-25.1-x86_64-linux-gnu.tar.gz
+ENV QTUM_FOLDER qtum-25.1
 
 ADD $QTUM_RELEASE_URL/$QTUM_ARCHIVE ./
 RUN tar -xzf $QTUM_ARCHIVE \


### PR DESCRIPTION
All Rosetta tests are passing:

## Rosetta test results

### `check:data` (Mainnet)
![mainnet-check-data](https://github.com/qtumproject/rosetta-qtum/assets/30988309/abfe15e5-8664-4e0f-93b2-e0cc8c73a726)

### `check-data` (Testnet)
![testnet-check-data](https://github.com/qtumproject/rosetta-qtum/assets/30988309/fb1e6ad6-b1dc-4213-a717-91b7b0d43aee)

### `check:construction` (Testnet)
![Testnet-check-construction](https://github.com/qtumproject/rosetta-qtum/assets/30988309/3f7e4df3-c793-47f7-93c9-80bb498c52bc)
